### PR TITLE
fix (rollup255): removes a small rectangle in the bottom right of the contact list

### DIFF
--- a/src/pages/contacts/index.vue
+++ b/src/pages/contacts/index.vue
@@ -320,7 +320,7 @@ h2 {
 
 .contactsListContainer {
   max-height: 300px !important;
-  overflow: scroll !important;
+  overflow-y: scroll !important;
   margin-top: 0;
 }
 


### PR DESCRIPTION
Before
![image](https://github.com/rsksmart/rif-rollup-wallet/assets/66392159/65350d27-ed8b-4987-82bb-fb9c7f72748d)

Now
![image](https://github.com/rsksmart/rif-rollup-wallet/assets/66392159/0e1f4ed4-2b99-405b-8881-849edbcac729)
