### PR TITLE
fix: change all the links to L1 and L2 explorer

### DIFF
--- a/src/blocks/Footer.vue
+++ b/src/blocks/Footer.vue
@@ -64,7 +64,7 @@ export default Vue.extend({
   },
   computed: {
     blockExplorerLink(): string {
-      return this.$store.getters["zk-onboard/config"].zkSyncNetwork.explorer;
+      return this.$store.getters["zk-onboard/config"].zkSyncNetwork.rollupExplorer;
     },
     isDarkTheme(): boolean {
       return this.theme === "dark";

--- a/src/blocks/IndexHeader.vue
+++ b/src/blocks/IndexHeader.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
         },
         {
           name: "Block Explorer",
-          link: this.config.zkSyncNetwork.explorer,
+          link: this.config.zkSyncNetwork.rollupExplorer,
         },
         {
           name: "zkCheckout",

--- a/src/blocks/LoadingBlock.vue
+++ b/src/blocks/LoadingBlock.vue
@@ -49,10 +49,10 @@ export default Vue.extend({
         case "Mint":
         case "Allowance":
         case "Deposit":
-          return this.config.ethereumNetwork.explorer + "tx/" + this.activeTransaction.txHash;
+          return this.config.ethereumNetwork.rskExplorer + "tx/" + this.activeTransaction.txHash;
 
         default:
-          return this.config.zkSyncNetwork.explorer + "explorer/transactions/" + this.activeTransaction.txHash;
+          return this.config.zkSyncNetwork.rollupExplorer + "transactions/" + this.activeTransaction.txHash;
       }
     },
     tip(): string {

--- a/src/blocks/SuccessBlock.vue
+++ b/src/blocks/SuccessBlock.vue
@@ -20,12 +20,21 @@
       </template>
     </p>
     <a
-      v-if="txLink"
+      v-if="isL1Transaction()"
       id="btn-link-to-transaction"
-      :href="txLink"
+      :href="getL1ExplorerTransactionLink()"
       class="_display-block _text-center _margin-top-1"
       target="_blank"
-      >Link to the transaction
+      >Rootstock transacion
+      <v-icon name="ri-external-link-line"></v-icon>
+    </a>
+    <a
+      v-if="isL2Transaction()"
+      id="btn-link-to-transaction"
+      :href="getL2ExplorerTransactionLink()"
+      class="_display-block _text-center _margin-top-1"
+      target="_blank"
+      >Rollup transacion
       <v-icon name="ri-external-link-line"></v-icon>
     </a>
     <div v-if="activeTransaction.address" class="infoBlockItem smaller _margin-top-2">
@@ -127,6 +136,7 @@ export default Vue.extend({
   data() {
     return {
       displayAllowanceDeposit: false,
+      l1TransactionHash: "", // Used only for withdraw transactions
     };
   },
   computed: {
@@ -135,20 +145,6 @@ export default Vue.extend({
     },
     activeTransaction(): ZkActiveTransaction {
       return this.$store.getters["zk-transaction/activeTransaction"];
-    },
-    txLink(): string | undefined {
-      if (!this.activeTransaction.txHash) {
-        return undefined;
-      }
-      switch (this.activeTransaction.type) {
-        case "Mint":
-        case "Allowance":
-        case "Deposit":
-          return this.config.ethereumNetwork.explorer + "tx/" + this.activeTransaction.txHash;
-
-        default:
-          return this.config.zkSyncNetwork.explorer + "explorer/transactions/" + this.activeTransaction.txHash;
-      }
     },
     isOwnAddress(): boolean {
       return getAddress(this.$store.getters["zk-account/address"]) === getAddress(this.activeTransaction.address || "");
@@ -192,6 +188,18 @@ export default Vue.extend({
     },
     async clearActiveTransaction() {
       await this.$store.commit("zk-transaction/clearActiveTransaction");
+    },
+    getL1ExplorerTransactionLink(): string {
+      return this.config.ethereumNetwork.rskExplorer + "tx/" + this.activeTransaction.txHash;
+    },
+    getL2ExplorerTransactionLink(): string {
+      return this.config.zkSyncNetwork.rollupExplorer + "transactions/" + this.activeTransaction.txHash;
+    },
+    isL1Transaction(): boolean {
+      return ["Deposit", "Allowance", "Mint"].includes(this.activeTransaction.type);
+    },
+    isL2Transaction(): boolean {
+      return ["Deposit", "Transfer", "Withdraw"].includes(this.activeTransaction.type);
     },
   },
 });

--- a/src/blocks/modals/AccountModal.vue
+++ b/src/blocks/modals/AccountModal.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
       return this.$store.getters["zk-account/address"];
     },
     accountZkScanUrl(): string {
-      return (this.$store.getters["zk-onboard/config"].zkSyncNetwork.explorer +
+      return (this.$store.getters["zk-onboard/config"].zkSyncNetwork.rollupExplorer +
         "explorer/accounts/" +
         this.accountAddress) as string;
     },

--- a/src/blocks/modals/FooterModal.vue
+++ b/src/blocks/modals/FooterModal.vue
@@ -76,7 +76,7 @@ export default Vue.extend({
       },
     },
     blockExplorerLink(): string {
-      return this.$store.getters["zk-onboard/config"].zkSyncNetwork.explorer;
+      return this.$store.getters["zk-onboard/config"].zkSyncNetwork.rollupExplorer;
     },
     isDarkTheme(): boolean {
       return this.theme === "dark";

--- a/src/blocks/modals/NoTokenFound.vue
+++ b/src/blocks/modals/NoTokenFound.vue
@@ -22,7 +22,7 @@ export default Vue.extend({
   name: "NoTokenFound",
   computed: {
     blockExplorerLink(): string {
-      return this.$store.getters["zk-onboard/config"].zkSyncNetwork.explorer;
+      return this.$store.getters["zk-onboard/config"].zkSyncNetwork.rollupExplorer;
     },
     network() {
       return this.$store.getters["zk-provider/network"];

--- a/src/pages/token/_symbol.vue
+++ b/src/pages/token/_symbol.vue
@@ -123,7 +123,7 @@ export default Vue.extend({
       return !this.zkTokensLoading && this.token && this.symbol !== "RBTC";
     },
     blockExplorerLink(): string {
-      return this.$store.getters["zk-onboard/config"].ethereumNetwork.explorer;
+      return this.$store.getters["zk-onboard/config"].ethereumNetwork.rskExplorer;
     },
   },
   mounted() {


### PR DESCRIPTION
This PR fixes the links to both explorers (L1 and L2) and the "when" they are shown. 

In order to make the wallet run with this fix it is required to point to the a local copy to the latest version of the nuxt-core.
The default port of the L2 explorer is 7000. This version assumes it is running in that port. 

Some notes to take into consideration:

*****FOR THE TRANSACTIONS HISTORY TAB

When the item is a deposit
Only exists one hash, the L1 hash. Show both links but they should have the same transaction hash

When the item is a withdrawal
Show both links. L1 hash is different from L2 hash.

When the item is a transfer
Show only L2 link.

Change Pub Key (account activation)
Show only L2 link.

Mint and allowance
Not shown in this screen.

Note: For now (we are not using NFTs operations) the link to L2 will be always visible for any operation



*****FOR THE TRANSACTIONS WORKFLOW

Successful allowance
Show link to L1

Successful deposit
Show both links. The hash of the transaction, should be the same.

Successful mint
Show only L1 link.

Transfer L2 to L2
Show only L2 link.

Withdraw
Both links will eventually exist but in the success moment, the L2 transaction has not been processed so the L1 link is not available yet. Show only L2 link.



********ADITIONAL NOTES:
I'm assuming L1 links will work. This couldn't be tested in localhost.

It would be great to have a task to rename variables/functions and to refactor some things.

