### PR TITLE
fix: tx error tooltip not showing properly ROLLUP-330

### DIFF
--- a/src/assets/style/pages/_transactions.scss
+++ b/src/assets/style/pages/_transactions.scss
@@ -83,7 +83,7 @@
         display: block;
 
         .tooltip {
-          max-width: 200px;
+          max-width: 400px;
           height: auto;
           white-space: initial;
           width: max-content;

--- a/src/components/TransactionHistoryItem.vue
+++ b/src/components/TransactionHistoryItem.vue
@@ -19,7 +19,7 @@
         <div class="createdAt">{{ timeAgo }}</div>
         <template #body>{{ transaction.createdAt | formatDateTime }}</template>
       </i-tooltip>
-      <i-tooltip placement="right" class="status">
+      <i-tooltip placement="bottom-start" class="status">
         <v-icon :name="transactionStatus.icon" :class="transactionStatus.class" />
         <template #body>{{ transactionStatus.text }}</template>
       </i-tooltip>


### PR DESCRIPTION
I couldn´t replicate the tx failure, but anyway I change the position and make bigger the tooltip where the tx error will be shown. [Issue ROLLUP-330](https://rsklabs.atlassian.net/jira/software/projects/ROLLUP/boards/165/backlog?selectedIssue=ROLLUP-330)

<img width="908" alt="Screenshot 2023-08-28 at 3 59 54 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/a7890e19-e941-4f7b-a7fc-a62c655d7878">
