### PR TITLE
fix: tx amount breaking history item ui ROLLUP-345

### DIFF
--- a/src/assets/style/pages/_transactions.scss
+++ b/src/assets/style/pages/_transactions.scss
@@ -42,6 +42,13 @@
         font-weight: 500;
         line-height: 120%;
       }
+      .symbol {
+        display: inline-flex;
+        justify-content: flex-end;
+        color: #121212;
+        font-size: 16px;
+        height: 15px;
+      }
       .tokenSymbol {
         display: inline-flex;
         color: #121212;
@@ -163,7 +170,7 @@
       .actionInfo {
         width: 100%;
         display: grid;
-        grid-template-rows: 50% 50%;
+        grid-template-rows: 33% 33% 33%;
         grid-template-columns: 100%;
 
         .tokenPrice {

--- a/src/components/TransactionHistoryItem.vue
+++ b/src/components/TransactionHistoryItem.vue
@@ -26,7 +26,10 @@
     </div>
     <div class="actionInfo">
       <div v-if="!isNFT && !isSwap" :class="{ small: smallAmountText }" class="amount">
-        {{ itReducesMyBalance }} {{ amount | parseBigNumberish(tokenSymbol) }} {{ tokenSymbol }}
+        {{ itReducesMyBalance }} {{ amount | parseBigNumberish(tokenSymbol) }}
+      </div>
+      <div v-if="!isNFT && !isSwap" :class="{ small: smallAmountText }" class="symbol">
+        {{ tokenSymbol }}
       </div>
       <token-price :symbol="tokenSymbol" :amount="amount" />
       <template v-if="!isMintNFT && !isSwap">
@@ -419,6 +422,12 @@ export default Vue.extend({
     },
     isL1Transaction() {
       return ["Deposit", "Withdraw"].includes(this.transaction.op.type);
+    },
+    cropLongAmount(amount: BigNumberish): BigNumberish {
+      console.log("amount", amount);
+      console.log("Number(amount)", Number(amount));
+      console.log("toFixed", Number(amount).toFixed(5));
+      return amount;
     },
   },
 });


### PR DESCRIPTION
[ROLLUP-345](https://rsklabs.atlassian.net/jira/software/projects/ROLLUP/boards/165/backlog?selectedIssue=ROLLUP-345)
I propose this change (moving the token symbol to a different line) to avoid modifying the filter `parseBigNumberish` on package `nuxt-core` but it is open for discussion.

<img width="414" alt="Screenshot 2023-08-28 at 5 10 29 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/dd8fa577-6939-4c2f-bac0-f486192badcb">
<img width="431" alt="Screenshot 2023-08-29 at 9 43 44 AM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/5b4f1815-cc47-4eca-a945-d208f8878034">