### PR TITLE
chore(qa): changes qa rollup addr in env

### DIFF
--- a/environments/.env.coreqa
+++ b/environments/.env.coreqa
@@ -9,6 +9,7 @@ FIREBASE_FUNCTIONS_BASE_URL=https://us-central1-zksync-vue.cloudfunctions.net/
 
 RNS_REGISTRY_ADDRESS=0xcb868aeabd31e2b66f74e9a55cf064abb31a4ad5
 RNS_REGISTRY_NODE=https://public-node.rsk.co
-ROLLUP_SERVER_MAINNET=https://server-01.rollup.iovlabs.net:3001/api/v0.2/
+ROLLUP_BLOCK_EXPLORER=https://wallet.core.qa.rollup.rif.technology
+ROLLUP_SERVER_MAINNET=https://server-01.rollup.iovlabs.net:3001/api/v0.2
 ROLLUP_SERVER_TESTNET=https://server.testnet.rollup.iovlabs.net/api/v0.2
-ROLLUP_SERVER_LOCALHOST=https://localhost:3001/api/v0.2
+ROLLUP_SERVER_LOCALHOST=https://server.qa.rollup.rif.technology/api/v0.2


### PR DESCRIPTION
Modifies the .env.coreqa file to use the server deployed in the Core QA env

Refs:
- [ROLLUP-362](https://rsklabs.atlassian.net/browse/ROLLUP-362)
- [ROLLUP-363](https://rsklabs.atlassian.net/browse/ROLLUP-363)


Locally tested that it does try to connect to the correct server (although used env.local for that), but it fails with port 3030 (specified in the task). Works with 3001, however.

<img width="422" alt="Screenshot 2023-08-30 at 11 06 26" src="https://github.com/rsksmart/rif-rollup-wallet/assets/36888576/ea0ca2bc-b265-4d9f-8fc4-0703b5c7e956">

As to the explorer address, the app seems to disregard the configuration
<img width="617" alt="Screenshot 2023-08-30 at 11 33 56" src="https://github.com/rsksmart/rif-rollup-wallet/assets/36888576/83ec6852-0578-4eb8-b132-fe11f446f960">
