### PR TITLE
fix: deposit to L1 shown as positive value on history ROLLUP-348

### DIFF
--- a/src/components/TransactionHistoryItem.vue
+++ b/src/components/TransactionHistoryItem.vue
@@ -366,7 +366,7 @@ export default Vue.extend({
     itReducesMyBalance(): string {
       if (
         (this.transaction.op.type === "Transfer" && this.isSameAddress(this.transaction.op.from)) ||
-        (this.transaction.op.type === "Deposit" && this.isSameAddress(this.transaction.op.to)) ||
+        (this.transaction.op.type === "Deposit" && !this.isSameAddress(this.transaction.op.to)) ||
         this.transaction.op.type === "FullExit"
       ) {
         return "-";


### PR DESCRIPTION
[/ROLLUP-348](https://rsklabs.atlassian.net/browse/ROLLUP-348) Some txs like deposits are being treated as exit operations showing its amount as negative. Now only if the Deposit goes to a different account is shown as negative on the history.
<img width="462" alt="Screenshot 2023-08-30 at 10 07 56 AM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/3ff9ec1e-c52a-4cbb-b31d-892926a6bea7">