### PR TITLE
fix: background color change on picking suggested value from browser ROLLUP-352

### DIFF
--- a/src/assets/style/components/_walletAddress.scss
+++ b/src/assets/style/components/_walletAddress.scss
@@ -139,12 +139,12 @@ body.inkline.-dark .defaultLayout {
     background-color: $input-border-color-dark !important;
     align-items: center;
 
-    input {
-      color: $white;
+    #addressInput {
+      color: $white !important;
     }
     input:-webkit-autofill {
       -webkit-box-shadow: 0 0 0 1000px transparentize($color: #252e78, $amount: 0.1) inset !important;
-      -webkit-text-fill-color: $white;
+      -webkit-text-fill-color: $white !important;
     }
 
     .userImgPlaceholder {

--- a/src/assets/style/components/_walletAddress.scss
+++ b/src/assets/style/components/_walletAddress.scss
@@ -144,6 +144,7 @@ body.inkline.-dark .defaultLayout {
     }
     input:-webkit-autofill {
       -webkit-box-shadow: 0 0 0 1000px transparentize($color: #252e78, $amount: 0.1) inset !important;
+      -webkit-text-fill-color: $white;
     }
 
     .userImgPlaceholder {

--- a/src/assets/style/components/_walletAddress.scss
+++ b/src/assets/style/components/_walletAddress.scss
@@ -113,6 +113,9 @@ body.inkline.-light .defaultLayout {
     input {
       color: $black;
     }
+    input:-webkit-autofill {
+      -webkit-box-shadow: 0 0 0 1000px white inset !important;
+    }
 
     .userImgPlaceholder {
       background-color: $white;
@@ -138,6 +141,9 @@ body.inkline.-dark .defaultLayout {
 
     input {
       color: $white;
+    }
+    input:-webkit-autofill {
+      -webkit-box-shadow: 0 0 0 1000px transparentize($color: #252e78, $amount: 0.1) inset !important;
     }
 
     .userImgPlaceholder {

--- a/src/assets/style/pages/_contacts.scss
+++ b/src/assets/style/pages/_contacts.scss
@@ -141,6 +141,10 @@
 
 body.inkline {
   &.-light {
+    input#contactNameInput:-webkit-autofill {
+      -webkit-box-shadow: 0 0 0 1000px white inset !important;
+    }
+
     .contactsListContainer {
       &::-webkit-scrollbar-thumb {
         background-color: $input-border-color-focus-light;
@@ -153,6 +157,20 @@ body.inkline {
   }
 
   &.-dark {
+    .contactsPage {
+      input#contactNameInput:-webkit-autofill {
+        -webkit-box-shadow: 0 0 0 1000px white inset !important;
+      }
+
+      .defaultLayout .walletContainer input {
+        color: $black !important;
+      }
+      input#addressInput:-webkit-autofill {
+        -webkit-text-fill-color: $black !important;
+        -webkit-box-shadow: 0 0 0 1000px white inset !important;
+      }
+    }
+
     .contactsListContainer {
       &::-webkit-scrollbar-thumb {
         background-color: $input-border-color-focus-dark;

--- a/src/assets/style/pages/_transactions.scss
+++ b/src/assets/style/pages/_transactions.scss
@@ -416,6 +416,10 @@ body.inkline {
   }
 
   &.-dark {
+    input#addressInput:-webkit-autofill {
+      -webkit-box-shadow: 0 0 0 1000px transparentize($color: #252e78, $amount: 0.1) inset !important;
+      -webkit-text-fill-color: $white !important;
+    }
     .transactionsPage .transactionsListContainer {
       &::-webkit-scrollbar-thumb {
         background-color: $input-border-color-focus-dark;


### PR DESCRIPTION
[ROLLUP-352](https://rsklabs.atlassian.net/browse/ROLLUP-352) When choosing a value suggested by the browser for addresses and contacts name.

<img width="473" alt="Screenshot 2023-08-31 at 12 13 39 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/5d474dae-3dc6-4015-a22d-1b79dc93c447">
<img width="471" alt="Screenshot 2023-08-31 at 12 13 50 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/9c70941f-2e59-4ade-ace8-c7d451b8a141">
<img width="533" alt="Screenshot 2023-08-31 at 12 14 00 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/380a258d-379f-4c7c-ac97-38dae6aa8d98">
<img width="530" alt="Screenshot 2023-08-31 at 12 14 16 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/d67017ef-88ab-408b-8963-75d7bb21f908">
<img width="468" alt="Screenshot 2023-08-31 at 12 14 27 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/40bcd3ce-a594-4ed6-a3af-6861b7589d46">
<img width="475" alt="Screenshot 2023-08-31 at 12 14 35 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/44225dd5-4a08-4a42-ade3-6548f01e5591">
<img width="465" alt="Screenshot 2023-08-31 at 12 14 44 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/9158ea39-c1c6-4299-9837-5a97128d2d62">
<img width="469" alt="Screenshot 2023-08-31 at 12 14 57 PM" src="https://github.com/rsksmart/rif-rollup-wallet/assets/7018960/b112d16d-2c1c-464d-ae22-42fbb2be357f">
