### PR TITLE
chore: use correct rns registry address and pubic node for testnet env

### DIFF
--- a/environments/.env.testnet
+++ b/environments/.env.testnet
@@ -7,8 +7,8 @@ MOONPAY_MAINNET_API_PUBLIC_KEY=pk_live_cS0AkN9LR0qquMUk9w4JGsaeoplwEuD
 MIXPANEL_TOKEN=5600dbc62a772c26f25b8df97ee54701
 FIREBASE_FUNCTIONS_BASE_URL=https://us-central1-zksync-vue.cloudfunctions.net/
 
-RNS_REGISTRY_ADDRESS=0xcb868aeabd31e2b66f74e9a55cf064abb31a4ad5
-RNS_REGISTRY_NODE=https://public-node.rsk.co
+RNS_REGISTRY_ADDRESS=0x7d284aaac6e925aad802a53c0c69efe3764597b8
+RNS_REGISTRY_NODE=https://public-node.testnet.rsk.co
 ROLLUP_SERVER_MAINNET=https://server-01.rollup.iovlabs.net:3001/api/v0.2/
 ROLLUP_SERVER_TESTNET=https://server.testnet.rollup.rif.technology/api/v0.2
 ROLLUP_SERVER_LOCALHOST=http://localhost:3001/api/v0.2


### PR DESCRIPTION
This PR addresses this Issue: [ROLLUP-404](https://rsklabs.atlassian.net/browse/ROLLUP-404)