### PR TITLE
fix(vuln-448): delete service workker unregister script 

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,16 +5,5 @@
   </head>
   <body {{ BODY_ATTRS }}>
     {{ APP }}
-    <script>
-      try {
-        navigator.serviceWorker.getRegistrations().then(function (registrations) {
-          for (const registration of registrations) {
-            registration.unregister();
-          }
-        });
-      } catch (e) {
-        console.error(e);
-      }
-    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR addresses this [vulnerability](https://rsklabs.atlassian.net/browse/VULN-448).

The Project doesn't use service workers, so it makes no sense to have a service worker unregistration script, hence it was removed