### PR TITLE
fix: update server URL used in core QA

### DIFF
--- a/environments/.env.coreqa
+++ b/environments/.env.coreqa
@@ -3,5 +3,5 @@ IS_TWO_STEP_WITHDRAW_ENABLED=true
 RNS_REGISTRY_ADDRESS=0x7d284aaac6e925aad802a53c0c69efe3764597b8
 RNS_REGISTRY_NODE=https://public-node.testnet.rsk.co
 ROLLUP_SERVER_MAINNET=https://server-01.rollup.iovlabs.net:3001/api/v0.2/
-ROLLUP_SERVER_TESTNET=https://server.testnet.rollup.rif.technology/api/v0.2
+ROLLUP_SERVER_TESTNET=https://server.qa.rollup.rif.technology/api/v0.2
 ROLLUP_SERVER_LOCALHOST=http://localhost:3001/api/v0.2


### PR DESCRIPTION
## What

- update the server URL used in core QA env

## Why

- otherwise the dapp isn't working in that env