### PR TITLE
fix(ROLLUP-544): do not include all the process env variables

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,5 @@
 import { NuxtConfig } from "@nuxt/types";
 import { NuxtOptionsBuild } from "@nuxt/types/config/build";
-import { NuxtOptionsEnv } from "@nuxt/types/config/env";
 import { version as zkSyncVersion } from "@rsksmart/rif-rollup-js-sdk/package.json";
 
 import { ModuleOptions } from "@rsksmart/rif-rollup-nuxt-core/types";
@@ -44,10 +43,6 @@ const config = <NuxtConfig>{
       devtools: !isProduction,
     },
   },
-  env: {
-    ...process.env,
-    TEST_WORD: "cheta rocks",
-  } as NuxtOptionsEnv,
 
   publicRuntimeConfig: {
     mixpanel: {
@@ -234,10 +229,11 @@ const config = <NuxtConfig>{
         logoutRedirect: "/",
       },
     ],
+    ["@nuxtjs/dotenv", { path: __dirname }],
   ],
 
   // Nuxt.js modules
-  modules: ["@inkline/nuxt", "@nuxtjs/sentry", "@nuxtjs/proxy", "@nuxtjs/google-gtag"],
+  modules: ["@inkline/nuxt", "@nuxtjs/sentry", "@nuxtjs/proxy", "@nuxtjs/google-gtag", "@nuxtjs/dotenv"],
   inkline: {
     config: {
       autodetectVariant: false,

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@ethersproject/bignumber": "^5.5.0",
     "@nuxt/types": "^2.15.8",
     "@nuxt/typescript-build": "^2.1.0",
+    "@nuxtjs/dotenv": "^1.4.2",
     "@nuxtjs/google-fonts": "^1.3.0",
     "@nuxtjs/proxy": "^2.1.0",
     "@nuxtjs/style-resources": "^1.2.1",
@@ -133,7 +134,7 @@
     }
   },
   "scripts": {
-    "build": "yarn local && nuxt build",
+    "build": "yarn local && nuxt build --no-processenv",
     "ci:build:dev-mainnet": "sh cli-process-env.sh 'mainnet' dev 1 && yarn generate",
     "ci:build:prod": "yarn ci:prepare:mainnet && yarn generate",
     "ci:build:testnet": "yarn ci:prepare:testnet && yarn generate",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     }
   },
   "scripts": {
-    "build": "yarn local && nuxt build --no-processenv",
+    "build": "yarn local && nuxt build",
     "ci:build:dev-mainnet": "sh cli-process-env.sh 'mainnet' dev 1 && yarn generate",
     "ci:build:prod": "yarn ci:prepare:mainnet && yarn generate",
     "ci:build:testnet": "yarn ci:prepare:testnet && yarn generate",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5020,6 +5020,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxtjs/dotenv@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@nuxtjs/dotenv@npm:1.4.2"
+  dependencies:
+    consola: ^3.2.3
+    dotenv: ^8.2.0
+  checksum: b1251be9401bdcce536879cec01631ab0a9a64d2b07b02b985fd5d09b0ae17c7cdb4921953fc535c3ae5e4a5b2769576e4dfcaf713668a4fbd4242d44b981a99
+  languageName: node
+  linkType: hard
+
 "@nuxtjs/eslint-config-typescript@npm:^8.0.0":
   version: 8.0.0
   resolution: "@nuxtjs/eslint-config-typescript@npm:8.0.0"
@@ -5353,6 +5363,7 @@ __metadata:
     "@nuxt/types": ^2.15.8
     "@nuxt/typescript-build": ^2.1.0
     "@nuxt/typescript-runtime": ^2.1.0
+    "@nuxtjs/dotenv": ^1.4.2
     "@nuxtjs/google-fonts": ^1.3.0
     "@nuxtjs/google-gtag": ^1.0.4
     "@nuxtjs/proxy": ^2.1.0
@@ -11206,6 +11217,13 @@ __metadata:
   version: 16.3.1
   resolution: "dotenv@npm:16.3.1"
   checksum: 15d75e7279018f4bafd0ee9706593dd14455ddb71b3bcba9c52574460b7ccaf67d5cf8b2c08a5af1a9da6db36c956a04a1192b101ee102a3e0cf8817bbcf3dfd
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^8.2.0":
+  version: 8.6.0
+  resolution: "dotenv@npm:8.6.0"
+  checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Use `dotenv` to read env variables from `.env` file

## Why

- All the `process.env` variables are currently loaded and stored into the artefacts